### PR TITLE
Enable opening and closing of TdlpackFile with context manager. with …

### DIFF
--- a/pytdlpack/_pytdlpack.py
+++ b/pytdlpack/_pytdlpack.py
@@ -406,6 +406,13 @@ class TdlpackFile(object):
             if not k.startswith('_'):
                 strings.append('%s = %s\n'%(k,self.__dict__[k]))
         return ''.join(strings)
+
+    def __enter__(self):
+        """no additional setup as opening with context manager is not required"""
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
     
     def _determine_record_type(self,ipack,ioctet):
         kwargs = {}


### PR DESCRIPTION
…pytdlpack.open('test.sq') as f:

Hi Eric,

Feel free to take this change.
The __enter__ method is required for PytdlpackFile to behave as a context manager.
The pytdlpack.open is still responsible for the entirety of the "setup" and nothing extra occurs in __enter__
The PytdlpackFile.close() method is called upon exiting the context manager in __exit__
The user isn't required to use the "with" syntax and can explicitly track opening and closing if they wish.

Adam